### PR TITLE
disallow the use of css libs and Angular Material

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Create an Angular 2+ application which runs in the browser and satisfies the fol
 - The use of a CSS pre-processing tool like SCSS/LESS
 - Consideration of semantic markup, SEO and accessibility
 
-Think carefully when introducing third party libraries, Angular as a framework has everything you need to accomplish the challenge so only do it if you really must, for example, adding additional functionality.
+Think carefully when introducing third party libraries (including Angular Material), the Angular framework has everything you need to accomplish the challenge so only do it if you really must, for example, adding additional functionality.
 
 _OR_
 
@@ -71,6 +71,7 @@ You are more than welcome to use the following starting points.
 - The use of a CSS pre-processing tool
   - SCSS/LESS/CSSinJS like (Emotion/styledComponents/Vanilla Extract)
 - Consideration of semantic markup, SEO and accessibility
+- Avoid using css libraries
 
 _OR_
 


### PR DESCRIPTION
No need to use css libraries in such a small project, this will help to better judge css skills. Explicit disallowing the use of Angular Material, native elements are enough to accomplish the challenge and allow to better judge the experience of the user.